### PR TITLE
fix typo in git command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ To create new articles - run `hugo new faq/my-faq-post.md`. This generates a fil
 ## Building
 
 1. [Install `hugo`](https://gohugo.io/getting-started/installing#readout).
-2. Run `git submodules update --init` to download the theme if you haven't already
+2. Run `git submodule update --init` to download the theme if you haven't already
 3. Run `hugo server -D` then navigate to [http://localhost:1313/cpp-faq/](http://localhost:1313/cpp-faq/) in your browser.


### PR DESCRIPTION
```
git: 'submodules' is not a git command. See 'git --help'.

The most similar command is
        submodule
```